### PR TITLE
Subscription persistence and Subscription Interface

### DIFF
--- a/news-aggregation/definitions/ISubscription.ts
+++ b/news-aggregation/definitions/ISubscription.ts
@@ -1,0 +1,10 @@
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+
+export interface ISubscription {
+    userId: string;
+    interval: string;
+    createdOn: Date;
+    user: IUser;
+    room: IRoom;
+}

--- a/news-aggregation/persistence/RoomSubscriptionPersistence.ts
+++ b/news-aggregation/persistence/RoomSubscriptionPersistence.ts
@@ -69,7 +69,33 @@ export class RoomSubscriptionPersistence {
         }
     }
 
-    async getSubscribedRooms(): Promise<Array<ISubscription>> {
+    async getSubscribedRooms(room: IRoom): Promise<Array<ISubscription>> {
+        const associations: Array<RocketChatAssociationRecord> = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                "news-aggregation-subscription",
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.ROOM,
+                room.id,
+            ),
+        ];
+
+        let subscriptions: Array<ISubscription>;
+        try {
+            subscriptions = (await this.persistenceRead.readByAssociations(
+                associations,
+            )) as Array<ISubscription>;
+        } catch (err) {
+            subscriptions = [];
+            console.error("Could not get subscribed rooms", err);
+            this.app.getLogger().info("Could not get subscribed rooms", err);
+        }
+
+        return subscriptions;
+    }
+
+    async getSubscriptions(): Promise<Array<ISubscription>> {
         const associations: Array<RocketChatAssociationRecord> = [
             new RocketChatAssociationRecord(
                 RocketChatAssociationModel.MISC,
@@ -84,8 +110,8 @@ export class RoomSubscriptionPersistence {
             )) as Array<ISubscription>;
         } catch (err) {
             subscriptions = [];
-            console.error("Could not get subscribed rooms", err);
-            this.app.getLogger().info("Could not get subscribed rooms", err);
+            console.error("Could not get subscriptions", err);
+            this.app.getLogger().info("Could not get subscriptions", err);
         }
 
         return subscriptions;

--- a/news-aggregation/persistence/RoomSubscriptionPersistence.ts
+++ b/news-aggregation/persistence/RoomSubscriptionPersistence.ts
@@ -25,4 +25,47 @@ export class RoomSubscriptionPersistence {
         this.persistenceRead = persistenceRead;
         this.persistence = persistence;
     }
+
+    async createSubscription(interval: string, user: IUser, room: IRoom) {
+        const associations: Array<RocketChatAssociationRecord> = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                "news-aggregation-subscription",
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                interval,
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.USER,
+                user.id,
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.ROOM,
+                room.id,
+            ),
+        ];
+
+        let subscriptionRecord: ISubscription = {
+            userId: user.id,
+            interval: interval,
+            createdOn: new Date(),
+            user: user,
+            room: room,
+        };
+
+        let subscriptionId: string;
+        try {
+            subscriptionId = await this.persistence.createWithAssociations(
+                subscriptionRecord,
+                associations,
+            );
+            console.log("subscription created!!", subscriptionId);
+        } catch (err) {
+            console.error("Could not create news subscription", err);
+            this.app
+                .getLogger()
+                .info("Could not create news subscription", err);
+        }
+    }
 }

--- a/news-aggregation/persistence/RoomSubscriptionPersistence.ts
+++ b/news-aggregation/persistence/RoomSubscriptionPersistence.ts
@@ -117,6 +117,34 @@ export class RoomSubscriptionPersistence {
         return subscriptions;
     }
 
+    async getSubscriptionById(
+        subscriptionId: string,
+    ): Promise<Array<ISubscription>> {
+        const associations: Array<RocketChatAssociationRecord> = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                "news-aggregation-subscription",
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                subscriptionId,
+            ),
+        ];
+
+        let subscriptions: Array<ISubscription>;
+        try {
+            subscriptions = (await this.persistenceRead.readByAssociations(
+                associations,
+            )) as Array<ISubscription>;
+        } catch (err) {
+            subscriptions = [];
+            console.error("Could not get subscriptions", err);
+            this.app.getLogger().info("Could not get subscriptions", err);
+        }
+
+        return subscriptions;
+    }
+
     async deleteSubscriptionsByRoom(room: IRoom) {
         const associations: Array<RocketChatAssociationRecord> = [
             new RocketChatAssociationRecord(

--- a/news-aggregation/persistence/RoomSubscriptionPersistence.ts
+++ b/news-aggregation/persistence/RoomSubscriptionPersistence.ts
@@ -160,4 +160,38 @@ export class RoomSubscriptionPersistence {
                 .info("Could not delete subscriptions by room", err);
         }
     }
+
+    async deleteSubscriptionById(
+        subscriptionId: string,
+        room: IRoom,
+        user: IUser,
+    ) {
+        const associations: Array<RocketChatAssociationRecord> = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                "news-aggregation-subscription",
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                subscriptionId,
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.ROOM,
+                room.id,
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.USER,
+                user.id,
+            ),
+        ];
+
+        try {
+            await this.persistence.removeByAssociations(associations);
+        } catch (err) {
+            console.error("Could not delete subscription by id", err);
+            this.app
+                .getLogger()
+                .info("Could not delete subscription by id", err);
+        }
+    }
 }

--- a/news-aggregation/persistence/RoomSubscriptionPersistence.ts
+++ b/news-aggregation/persistence/RoomSubscriptionPersistence.ts
@@ -116,4 +116,48 @@ export class RoomSubscriptionPersistence {
 
         return subscriptions;
     }
+
+    async deleteSubscriptionsByRoom(room: IRoom) {
+        const associations: Array<RocketChatAssociationRecord> = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                "news-aggregation-subscription",
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.ROOM,
+                room.id,
+            ),
+        ];
+
+        try {
+            await this.persistence.removeByAssociations(associations);
+        } catch (err) {
+            console.error("Could not delete subscriptions by room", err);
+            this.app
+                .getLogger()
+                .info("Could not delete subscriptions by room", err);
+        }
+    }
+
+    async deleteSubscriptionsByUser(user: IUser) {
+        const associations: Array<RocketChatAssociationRecord> = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                "news-aggregation-subscription",
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.USER,
+                user.id,
+            ),
+        ];
+
+        try {
+            await this.persistence.removeByAssociations(associations);
+        } catch (err) {
+            console.error("Could not delete subscriptions by room", err);
+            this.app
+                .getLogger()
+                .info("Could not delete subscriptions by room", err);
+        }
+    }
 }

--- a/news-aggregation/persistence/RoomSubscriptionPersistence.ts
+++ b/news-aggregation/persistence/RoomSubscriptionPersistence.ts
@@ -1,0 +1,28 @@
+import {
+    IPersistence,
+    IPersistenceRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import { NewsAggregationApp } from "../NewsAggregationApp";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import {
+    RocketChatAssociationModel,
+    RocketChatAssociationRecord,
+} from "@rocket.chat/apps-engine/definition/metadata";
+import { ISubscription } from "../definitions/ISubscription";
+
+export class RoomSubscriptionPersistence {
+    app: NewsAggregationApp;
+    persistenceRead: IPersistenceRead;
+    persistence: IPersistence;
+
+    constructor(
+        app: NewsAggregationApp,
+        persistenceRead: IPersistenceRead,
+        persistence: IPersistence,
+    ) {
+        this.app = app;
+        this.persistenceRead = persistenceRead;
+        this.persistence = persistence;
+    }
+}

--- a/news-aggregation/persistence/RoomSubscriptionPersistence.ts
+++ b/news-aggregation/persistence/RoomSubscriptionPersistence.ts
@@ -68,4 +68,26 @@ export class RoomSubscriptionPersistence {
                 .info("Could not create news subscription", err);
         }
     }
+
+    async getSubscribedRooms(): Promise<Array<ISubscription>> {
+        const associations: Array<RocketChatAssociationRecord> = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                "news-aggregation-subscription",
+            ),
+        ];
+
+        let subscriptions: Array<ISubscription>;
+        try {
+            subscriptions = (await this.persistenceRead.readByAssociations(
+                associations,
+            )) as Array<ISubscription>;
+        } catch (err) {
+            subscriptions = [];
+            console.error("Could not get subscribed rooms", err);
+            this.app.getLogger().info("Could not get subscribed rooms", err);
+        }
+
+        return subscriptions;
+    }
 }

--- a/news-aggregation/persistence/SubscriptionPersistence.ts
+++ b/news-aggregation/persistence/SubscriptionPersistence.ts
@@ -11,7 +11,7 @@ import {
 } from "@rocket.chat/apps-engine/definition/metadata";
 import { ISubscription } from "../definitions/ISubscription";
 
-export class RoomSubscriptionPersistence {
+export class SubscriptionPersistence {
     app: NewsAggregationApp;
     persistenceRead: IPersistenceRead;
     persistence: IPersistence;


### PR DESCRIPTION
**This PR provides the funcitonality of querying the NewsSubscription{} into/from Rocket.Chat persistence storage.**

It addresses the following:

- [X] Create `SubscriptionPersistence class{}`
- [X] Define class methods like -> `createSubscription() getSubscribedRooms() getSubscriptions() getSubscriptionById() deleteSubscriptionsByRoom() deleteSubscriptionsByUser() deleteSubscriptionById()`