### PR TITLE
Get-News on demand from persistence (`/news get`)

### DIFF
--- a/news-aggregation/adapters/INewsSourceAdapter.ts
+++ b/news-aggregation/adapters/INewsSourceAdapter.ts
@@ -21,4 +21,20 @@ export interface INewsSourceAdapter {
 		persistence: IPersistence,
 		persistenceRead: IPersistenceRead
 	): Promise<any>;
+
+	getNews(
+		read: IRead,
+		modify: IModify,
+		room: IRoom,
+		http: IHttp,
+		persis: IPersistence
+	): Promise<NewsItem[]>;
+
+	deleteNews(
+		read: IRead,
+		modify: IModify,
+		room: IRoom,
+		http: IHttp,
+		persis: IPersistence
+	): Promise<any>;
 }

--- a/news-aggregation/adapters/source-adapters/TechCrunchAdapter.ts
+++ b/news-aggregation/adapters/source-adapters/TechCrunchAdapter.ts
@@ -29,6 +29,7 @@ export class TechCrunchAdapter implements INewsSourceAdapter {
 			console.log('Res:', response.data, 'Done');
 
 			this.newsItems = response?.data?.map((newsItem) => ({
+				id: newsItem.id.toString(),
 				title: newsItem.yoast_head_json.title,
 				description: newsItem.yoast_head_json.description,
 				link: newsItem.link,
@@ -64,6 +65,48 @@ export class TechCrunchAdapter implements INewsSourceAdapter {
 		} catch (err) {
 			console.error('News Items could not be save', err);
 			this.app.getLogger().error('News Items could not be save', err);
+		}
+	}
+
+	public async getNews(
+		read: IRead,
+		modify: IModify,
+		room: IRoom,
+		http: IHttp,
+		persis: IPersistence
+	): Promise<NewsItem[]> {
+		const persisRead = read.getPersistenceReader();
+		const newsStorage = new NewsItemPersistence(this.app, persis, persisRead);
+
+		let newsObject: NewsItem[];
+		try {
+			newsObject = (await newsStorage.getAllNewsById(
+				this.newsItems
+			)) as NewsItem[];
+			// console.log('news fetched FROM PERSIS');
+		} catch (err) {
+			newsObject = [];
+			console.error(err);
+			this.app.getLogger().error(err);
+		}
+		return newsObject;
+	}
+
+	public async deleteNews(
+		read: IRead,
+		modify: IModify,
+		room: IRoom,
+		http: IHttp,
+		persis: IPersistence
+	) {
+		const persisRead = read.getPersistenceReader();
+		const newsStorage = new NewsItemPersistence(this.app, persis, persisRead);
+
+		try {
+			await newsStorage.removeAllNews();
+			console.log('Removed all news !!!');
+		} catch (err) {
+			console.error(err);
 		}
 	}
 }

--- a/news-aggregation/definitions/NewsItem.ts
+++ b/news-aggregation/definitions/NewsItem.ts
@@ -1,30 +1,30 @@
 export class NewsItem {
-    id: string;
-    title: string;
-    description: string;
-    link: string;
-    image: string;
-    source: string;
-    author?: string;
-    publishedAt?: Date;
+	id: string;
+	title: string;
+	description: string;
+	link: string;
+	image: string;
+	source: string;
+	author?: string;
+	publishedAt?: Date;
 
-    constructor(
-        id: string,
-        title: string,
-        description: string,
-        link: string,
-        image: string,
-        source: string,
-        author: string,
-        publishedAt: Date,
-    ) {
-        this.id = id;
-        this.title = title;
-        this.description = description;
-        this.link = link;
-        this.image = image;
-        this.source = source;
-        this.author = author;
-        this.publishedAt = publishedAt;
-    }
+	constructor(
+		id: string,
+		title: string,
+		description: string,
+		link: string,
+		image: string,
+		source: string,
+		author: string,
+		publishedAt: Date
+	) {
+		this.id = id;
+		this.title = title;
+		this.description = description;
+		this.link = link;
+		this.image = image;
+		this.source = source;
+		this.author = author;
+		this.publishedAt = publishedAt;
+	}
 }

--- a/news-aggregation/definitions/NewsSource.ts
+++ b/news-aggregation/definitions/NewsSource.ts
@@ -49,6 +49,18 @@ export class NewsSource {
 		modify: IModify,
 		room: IRoom,
 		http: IHttp,
-		persistenceRead: IPersistenceRead
-	): Promise<any> {}
+		persis: IPersistence
+	): Promise<NewsItem[]> {
+		return this.adapter.getNews(read, modify, room, http, persis);
+	}
+
+	async deleteNews(
+		read: IRead,
+		modify: IModify,
+		room: IRoom,
+		http: IHttp,
+		persis: IPersistence
+	) {
+		return this.adapter.deleteNews(read, modify, room, http, persis);
+	}
 }

--- a/news-aggregation/enums/commandEnum.ts
+++ b/news-aggregation/enums/commandEnum.ts
@@ -1,5 +1,7 @@
 export enum CommandEnum {
 	ALERT = 'alert',
+	GET = 'get',
+	DELETE = 'delete',
 	SUBSCRIBE = 'subscribe',
 	UNSUBSCRIBE = 'unsubscribe',
 	HELP = 'help',

--- a/news-aggregation/persistence/NewsItemPersistence.ts
+++ b/news-aggregation/persistence/NewsItemPersistence.ts
@@ -37,10 +37,10 @@ export class NewsItemPersistence {
 		let recordId: string;
 		try {
 			recordId = await this.persistence.createWithAssociations(
-				{ newsItem: news },
+				news,
 				associations
 			);
-			console.log('News saved in Peristence!!', recordId);
+			console.log('News saved in Persistence!!', recordId);
 		} catch (err) {
 			console.error('Could not save news in persistence.', err);
 			this.app.getLogger().error('Could not save news in persistence.', err);
@@ -66,7 +66,7 @@ export class NewsItemPersistence {
 	//     associations.push(idAssociation);
 	// }
 
-	async getAllNewsById(allNews: NewsItem[]) {
+	async getAllNewsById(allNews: NewsItem[]): Promise<object[]> {
 		const associations: Array<RocketChatAssociationRecord> = [
 			new RocketChatAssociationRecord(
 				RocketChatAssociationModel.MISC,
@@ -84,17 +84,23 @@ export class NewsItemPersistence {
 
 		let allNewsObjectArray: object[];
 		try {
-			allNewsObjectArray =
-				await this.persistenceRead.readByAssociations(associations);
+			allNewsObjectArray = (await this.persistenceRead.readByAssociations(
+				associations
+			)) as NewsItem[];
 
 			if (allNewsObjectArray.length === 0) {
 				console.error("News doesn't exist");
 				this.app.getLogger().error("News doesn't exist");
+				return allNewsObjectArray;
 			}
+			// console.log('news exist in persistence', allNewsObjectArray);
 		} catch (err) {
+			allNewsObjectArray = [];
 			console.error('Could not get the all news by id', err);
 			this.app.getLogger().error('Could not get the all news by id', err);
 		}
+
+		return allNewsObjectArray;
 	}
 
 	async getNewsById(news: NewsItem): Promise<object[]> {
@@ -157,6 +163,7 @@ export class NewsItemPersistence {
 
 		try {
 			await this.persistence.removeByAssociations(associations);
+			console.log('removed!');
 		} catch (err) {
 			console.error('Could not remove all news from persistence.', err);
 			this.app

--- a/news-aggregation/utils/commandUtility.ts
+++ b/news-aggregation/utils/commandUtility.ts
@@ -30,6 +30,7 @@ export class CommandUtility implements ICommandUtility {
 	persistence: IPersistence;
 	persistenceRead: IPersistenceRead;
 	app: NewsAggregationApp;
+	// news: NewsItem[];
 
 	constructor(props: ICommandUtilityParams) {
 		this.sender = props.sender;
@@ -64,6 +65,7 @@ export class CommandUtility implements ICommandUtility {
 		const techCrunchNewsSource = new NewsSource(
 			this.app,
 			techCrunchAdapter,
+			// this.news
 			news
 		);
 		news = await techCrunchNewsSource.fetchNews(
@@ -77,11 +79,54 @@ export class CommandUtility implements ICommandUtility {
 		await techCrunchNewsSource.saveNews(this.persistence, this.persistenceRead);
 	}
 
-	// public async getNewsFromSource() {
-	//     const news: NewsItem[] = [];
-	//     const techCrunchSource = new TechCrunchNewsSource(this.app, news);
-	//     await techCrunchSource.
-	// }
+	public async getNewsFromSource() {
+		let news: NewsItem[] = [];
+
+		const techCrunchAdapter = new TechCrunchAdapter();
+		const techCrunchNewsSource = new NewsSource(
+			this.app,
+			techCrunchAdapter,
+			// this.news
+			news
+		);
+
+		try {
+			news = await techCrunchNewsSource.getNews(
+				this.read,
+				this.modify,
+				this.room,
+				this.http,
+				this.persistence
+			);
+			console.log('fetched!!', news, 'FETCHED FROM PERSISTENCE!');
+		} catch (err) {
+			console.error(err);
+		}
+	}
+
+	public async deleteNewsFromPersistence() {
+		let news: NewsItem[] = [];
+		const techCrunchAdapter = new TechCrunchAdapter();
+		const techCrunchNewsSource = new NewsSource(
+			this.app,
+			techCrunchAdapter,
+			news
+		);
+
+		try {
+			await techCrunchNewsSource.deleteNews(
+				this.read,
+				this.modify,
+				this.room,
+				this.http,
+				this.persistence
+			);
+
+			console.log('all news deleted!');
+		} catch (err) {
+			console.error(err);
+		}
+	}
 
 	public async subscribeNews() {
 		console.log('news subscribe working.');
@@ -99,6 +144,14 @@ export class CommandUtility implements ICommandUtility {
 		switch (singleParamCommand) {
 			case CommandEnum.ALERT:
 				await this.fetchNewsFromSource();
+				break;
+
+			case CommandEnum.GET:
+				await this.getNewsFromSource();
+				break;
+
+			case CommandEnum.DELETE:
+				await this.deleteNewsFromPersistence();
 				break;
 
 			case CommandEnum.SUBSCRIBE:


### PR DESCRIPTION
This PR includes the following: 

- [x] Create adapter methods for `GET and DELETE`
- [x] Create methods for the `TechCrunch Source`
- [x] Add a temporary `DELETE` news command (for dev purposes)
- [x] **FETCH the saved news from persistence storage.**


### Demo (console.log() saved news on terminal):

[screen-capture (4).webm](https://github.com/RocketChat/Apps.News-Aggregation/assets/95426993/65f38e6d-c779-4814-ad77-a7aece79e950)
