### PR TITLE
ElementBuilder Setup

### DIFF
--- a/news-aggregation/builders/ElementBuilder.ts
+++ b/news-aggregation/builders/ElementBuilder.ts
@@ -1,13 +1,19 @@
 import {
 	BlockElementType,
 	ButtonElement,
+	MultiStaticSelectElement,
+	Option,
 	StaticSelectElement,
 	TextObjectType,
 } from '@rocket.chat/ui-kit';
 import { ButtonParam } from '../ui-kit/element/IButtonElement';
 import { IElementBuilder } from '../ui-kit/element/IElementBuilder';
 import { ElementInteractionParam } from '../ui-kit/element/IInteractionElement';
-import { StaticSelectParam } from '../ui-kit/element/IStaticSelectElement';
+import {
+	StaticSelectOptionParam,
+	StaticSelectParam,
+} from '../ui-kit/element/IStaticSelectElement';
+import { MultiStaticSelectParam } from '../ui-kit/element/IMultiStaticSelectElement';
 
 export class ElementBuilder implements IElementBuilder {
 	constructor(private readonly appId: string) {}
@@ -71,4 +77,35 @@ export class ElementBuilder implements IElementBuilder {
 
 		return dropdown;
 	}
+
+	public createDropdownOptions(param: StaticSelectOptionParam): Option[] {
+		const options: Array<Option> = param?.map((option) => {
+			const { text, value, description, url } = option;
+			const optionElement: Option = {
+				text: {
+					type: TextObjectType.PLAIN_TEXT,
+					text: text,
+					emoji: true,
+				},
+				value,
+				...(description
+					? {
+							description: {
+								type: TextObjectType.PLAIN_TEXT,
+								text: description,
+							},
+						}
+					: undefined),
+				url,
+			};
+			return optionElement;
+		});
+
+		return options;
+	}
+
+	public createMultiStaticSelectDropdown(
+		param: MultiStaticSelectParam,
+		interactionParam: ElementInteractionParam
+	): MultiStaticSelectElement {}
 }

--- a/news-aggregation/builders/ElementBuilder.ts
+++ b/news-aggregation/builders/ElementBuilder.ts
@@ -107,5 +107,38 @@ export class ElementBuilder implements IElementBuilder {
 	public createMultiStaticSelectDropdown(
 		param: MultiStaticSelectParam,
 		interactionParam: ElementInteractionParam
-	): MultiStaticSelectElement {}
+	): MultiStaticSelectElement {
+		const {
+			text,
+			options,
+			optionGroups,
+			maxSelectItems,
+			initialOption,
+			initialValue,
+			dispatchActionConfig,
+			confirm,
+		} = param;
+
+		const { blockId, actionId } = interactionParam;
+
+		const multiStaticSelectDropdown: MultiStaticSelectElement = {
+			type: BlockElementType.MULTI_STATIC_SELECT,
+			placeholder: {
+				type: TextObjectType.PLAIN_TEXT,
+				text: text,
+			},
+			options,
+			optionGroups,
+			maxSelectItems,
+			initialOption,
+			initialValue,
+			appId: this.appId,
+			blockId,
+			actionId,
+			dispatchActionConfig,
+			confirm,
+		};
+
+		return multiStaticSelectDropdown;
+	}
 }

--- a/news-aggregation/builders/ElementBuilder.ts
+++ b/news-aggregation/builders/ElementBuilder.ts
@@ -1,6 +1,7 @@
 import {
 	BlockElementType,
 	ButtonElement,
+	ImageElement,
 	MultiStaticSelectElement,
 	Option,
 	StaticSelectElement,
@@ -14,6 +15,7 @@ import {
 	StaticSelectParam,
 } from '../ui-kit/element/IStaticSelectElement';
 import { MultiStaticSelectParam } from '../ui-kit/element/IMultiStaticSelectElement';
+import { ImageParam } from '../ui-kit/element/IImageElement';
 
 export class ElementBuilder implements IElementBuilder {
 	constructor(private readonly appId: string) {}
@@ -140,5 +142,16 @@ export class ElementBuilder implements IElementBuilder {
 		};
 
 		return multiStaticSelectDropdown;
+	}
+
+	public createImage(param: ImageParam): ImageElement {
+		const { imageUrl, altText } = param;
+		const image: ImageElement = {
+			type: BlockElementType.IMAGE,
+			imageUrl,
+			altText,
+		};
+
+		return image;
 	}
 }

--- a/news-aggregation/builders/ElementBuilder.ts
+++ b/news-aggregation/builders/ElementBuilder.ts
@@ -1,0 +1,34 @@
+import { ButtonElement, TextObjectType } from '@rocket.chat/ui-kit';
+import { ButtonParam } from '../ui-kit/element/IButtonElement';
+import { IElementBuilder } from '../ui-kit/element/IElementBuilder';
+import { ElementInteractionParam } from '../ui-kit/element/IInteractionElement';
+
+export class ElementBuilder implements IElementBuilder {
+	constructor(private readonly appId: string) {}
+
+	public createButton(
+		param: ButtonParam,
+		interactionParam: ElementInteractionParam
+	): ButtonElement {
+		const { text, url, value, style, secondary } = param;
+		const { blockId, actionId } = interactionParam;
+
+		const button: ButtonElement = {
+			type: 'button',
+			text: {
+				type: TextObjectType.PLAIN_TEXT,
+				text: text,
+				emoji: true,
+			},
+			appId: this.appId,
+			blockId,
+			actionId,
+			url,
+			value,
+			style,
+			secondary: false,
+		};
+
+		return button;
+	}
+}

--- a/news-aggregation/builders/ElementBuilder.ts
+++ b/news-aggregation/builders/ElementBuilder.ts
@@ -1,7 +1,13 @@
-import { ButtonElement, TextObjectType } from '@rocket.chat/ui-kit';
+import {
+	BlockElementType,
+	ButtonElement,
+	StaticSelectElement,
+	TextObjectType,
+} from '@rocket.chat/ui-kit';
 import { ButtonParam } from '../ui-kit/element/IButtonElement';
 import { IElementBuilder } from '../ui-kit/element/IElementBuilder';
 import { ElementInteractionParam } from '../ui-kit/element/IInteractionElement';
+import { StaticSelectParam } from '../ui-kit/element/IStaticSelectElement';
 
 export class ElementBuilder implements IElementBuilder {
 	constructor(private readonly appId: string) {}
@@ -26,9 +32,43 @@ export class ElementBuilder implements IElementBuilder {
 			url,
 			value,
 			style,
-			secondary: false,
+			secondary: secondary,
 		};
 
 		return button;
+	}
+
+	public createDropdown(
+		param: StaticSelectParam,
+		interactionParam: ElementInteractionParam
+	): StaticSelectElement {
+		const {
+			options,
+			optionGroups,
+			initialOption,
+			initialValue,
+			dispatchActionConfig,
+			placeholder,
+		} = param;
+		const { blockId, actionId } = interactionParam;
+
+		const dropdown: StaticSelectElement = {
+			type: BlockElementType.STATIC_SELECT,
+			placeholder: {
+				type: TextObjectType.PLAIN_TEXT,
+				text: placeholder,
+				emoji: true,
+			},
+			options,
+			optionGroups,
+			initialOption,
+			initialValue,
+			appId: this.appId,
+			blockId,
+			actionId,
+			dispatchActionConfig,
+		};
+
+		return dropdown;
 	}
 }

--- a/news-aggregation/builders/ElementBuilder.ts
+++ b/news-aggregation/builders/ElementBuilder.ts
@@ -4,6 +4,7 @@ import {
 	ImageElement,
 	MultiStaticSelectElement,
 	Option,
+	PlainTextInputElement,
 	StaticSelectElement,
 	TextObjectType,
 } from '@rocket.chat/ui-kit';
@@ -16,6 +17,7 @@ import {
 } from '../ui-kit/element/IStaticSelectElement';
 import { MultiStaticSelectParam } from '../ui-kit/element/IMultiStaticSelectElement';
 import { ImageParam } from '../ui-kit/element/IImageElement';
+import { PlainTextInputParam } from '../ui-kit/element/IPlainTextInputElement';
 
 export class ElementBuilder implements IElementBuilder {
 	constructor(private readonly appId: string) {}
@@ -153,5 +155,40 @@ export class ElementBuilder implements IElementBuilder {
 		};
 
 		return image;
+	}
+
+	public createPlainTextInput(
+		param: PlainTextInputParam,
+		interactionParam: ElementInteractionParam
+	): PlainTextInputElement {
+		const {
+			text,
+			initialValue,
+			multiline,
+			minLength,
+			maxLength,
+			dispatchActionConfig,
+		} = param;
+
+		const { blockId, actionId } = interactionParam;
+
+		const input: PlainTextInputElement = {
+			type: BlockElementType.PLAIN_TEXT_INPUT,
+			placeholder: {
+				type: TextObjectType.PLAIN_TEXT,
+				text,
+				emoji: true,
+			},
+			appId: this.appId,
+			blockId,
+			actionId,
+			initialValue,
+			multiline,
+			minLength,
+			maxLength,
+			dispatchActionConfig,
+		};
+
+		return input;
 	}
 }

--- a/news-aggregation/ui-kit/element/IButtonElement.ts
+++ b/news-aggregation/ui-kit/element/IButtonElement.ts
@@ -1,8 +1,8 @@
-import { ButtonElement, PlainText } from '@rocket.chat/ui-kit';
+import { ButtonElement } from '@rocket.chat/ui-kit';
 
 export type ButtonParam = Pick<
 	ButtonElement,
 	'url' | 'value' | 'style' | 'secondary'
 > & {
-	text: PlainText;
+	text: string;
 };

--- a/news-aggregation/ui-kit/element/IButtonElement.ts
+++ b/news-aggregation/ui-kit/element/IButtonElement.ts
@@ -1,0 +1,8 @@
+import { ButtonElement, PlainText } from '@rocket.chat/ui-kit';
+
+export type ButtonParam = Pick<
+	ButtonElement,
+	'url' | 'value' | 'style' | 'secondary'
+> & {
+	text: PlainText;
+};

--- a/news-aggregation/ui-kit/element/IElementBuilder.ts
+++ b/news-aggregation/ui-kit/element/IElementBuilder.ts
@@ -27,10 +27,7 @@ export interface IElementBuilder {
 		interactionParam: ElementInteractionParam
 	): StaticSelectElement;
 
-	createDropdownOptions(
-		param: StaticSelectOptionParam,
-		interactionParam: ElementInteractionParam
-	): Array<Option>;
+	createDropdownOptions(param: StaticSelectOptionParam): Array<Option>;
 
 	createMultiStaticSelectDropdown(
 		param: MultiStaticSelectParam,

--- a/news-aggregation/ui-kit/element/IElementBuilder.ts
+++ b/news-aggregation/ui-kit/element/IElementBuilder.ts
@@ -1,5 +1,6 @@
 import {
 	ButtonElement,
+	MultiStaticSelectElement,
 	Option,
 	StaticSelectElement,
 } from '@rocket.chat/ui-kit';
@@ -9,6 +10,7 @@ import {
 	StaticSelectOptionParam,
 	StaticSelectParam,
 } from './IStaticSelectElement';
+import { MultiStaticSelectParam } from './IMultiStaticSelectElement';
 
 export interface IElementBuilder {
 	createButton(
@@ -25,4 +27,9 @@ export interface IElementBuilder {
 		param: StaticSelectOptionParam,
 		interactionParam: ElementInteractionParam
 	): Array<Option>;
+
+	createMultiStaticSelectDropdown(
+		param: MultiStaticSelectParam,
+		interactionParam: ElementInteractionParam
+	): MultiStaticSelectElement;
 }

--- a/news-aggregation/ui-kit/element/IElementBuilder.ts
+++ b/news-aggregation/ui-kit/element/IElementBuilder.ts
@@ -1,10 +1,28 @@
-import { ButtonElement } from '@rocket.chat/ui-kit';
+import {
+	ButtonElement,
+	Option,
+	StaticSelectElement,
+} from '@rocket.chat/ui-kit';
 import { ButtonParam } from './IButtonElement';
 import { ElementInteractionParam } from './IInteractionElement';
+import {
+	StaticSelectOptionParam,
+	StaticSelectParam,
+} from './IStaticSelectElement';
 
 export interface IElementBuilder {
 	createButton(
 		param: ButtonParam,
 		interactionParam: ElementInteractionParam
 	): ButtonElement;
+
+	createDropdown(
+		param: StaticSelectParam,
+		interactionParam: ElementInteractionParam
+	): StaticSelectElement;
+
+	createDropdownOptions(
+		param: StaticSelectOptionParam,
+		interactionParam: ElementInteractionParam
+	): Array<Option>;
 }

--- a/news-aggregation/ui-kit/element/IElementBuilder.ts
+++ b/news-aggregation/ui-kit/element/IElementBuilder.ts
@@ -34,10 +34,7 @@ export interface IElementBuilder {
 		interactionParam: ElementInteractionParam
 	): MultiStaticSelectElement;
 
-	createImage(
-		param: ImageParam,
-		interactionParam: ElementInteractionParam
-	): ImageElement;
+	createImage(param: ImageParam): ImageElement;
 
 	createPlainTextInput(
 		param: PlainTextInputParam,

--- a/news-aggregation/ui-kit/element/IElementBuilder.ts
+++ b/news-aggregation/ui-kit/element/IElementBuilder.ts
@@ -1,5 +1,6 @@
 import {
 	ButtonElement,
+	ImageElement,
 	MultiStaticSelectElement,
 	Option,
 	StaticSelectElement,
@@ -11,6 +12,7 @@ import {
 	StaticSelectParam,
 } from './IStaticSelectElement';
 import { MultiStaticSelectParam } from './IMultiStaticSelectElement';
+import { ImageParam } from './IImageElement';
 
 export interface IElementBuilder {
 	createButton(
@@ -32,4 +34,9 @@ export interface IElementBuilder {
 		param: MultiStaticSelectParam,
 		interactionParam: ElementInteractionParam
 	): MultiStaticSelectElement;
+
+	createImage(
+		param: ImageParam,
+		interactionParam: ElementInteractionParam
+	): ImageElement;
 }

--- a/news-aggregation/ui-kit/element/IElementBuilder.ts
+++ b/news-aggregation/ui-kit/element/IElementBuilder.ts
@@ -3,6 +3,7 @@ import {
 	ImageElement,
 	MultiStaticSelectElement,
 	Option,
+	PlainTextInputElement,
 	StaticSelectElement,
 } from '@rocket.chat/ui-kit';
 import { ButtonParam } from './IButtonElement';
@@ -13,6 +14,7 @@ import {
 } from './IStaticSelectElement';
 import { MultiStaticSelectParam } from './IMultiStaticSelectElement';
 import { ImageParam } from './IImageElement';
+import { PlainTextInputParam } from './IPlainTextInputElement';
 
 export interface IElementBuilder {
 	createButton(
@@ -39,4 +41,9 @@ export interface IElementBuilder {
 		param: ImageParam,
 		interactionParam: ElementInteractionParam
 	): ImageElement;
+
+	createPlainTextInput(
+		param: PlainTextInputParam,
+		interactionParam: ElementInteractionParam
+	): PlainTextInputElement;
 }

--- a/news-aggregation/ui-kit/element/IElementBuilder.ts
+++ b/news-aggregation/ui-kit/element/IElementBuilder.ts
@@ -1,0 +1,10 @@
+import { ButtonElement } from '@rocket.chat/ui-kit';
+import { ButtonParam } from './IButtonElement';
+import { ElementInteractionParam } from './IInteractionElement';
+
+export interface IElementBuilder {
+	createButton(
+		param: ButtonParam,
+		interactionParam: ElementInteractionParam
+	): ButtonElement;
+}

--- a/news-aggregation/ui-kit/element/IImageElement.ts
+++ b/news-aggregation/ui-kit/element/IImageElement.ts
@@ -1,0 +1,3 @@
+import { ImageElement } from '@rocket.chat/ui-kit';
+
+export type ImageParam = Pick<ImageElement, 'imageUrl' | 'altText'>;

--- a/news-aggregation/ui-kit/element/IInteractionElement.ts
+++ b/news-aggregation/ui-kit/element/IInteractionElement.ts
@@ -1,0 +1,1 @@
+export type ElementInteractionParam = { blockId: string; actionId: string };

--- a/news-aggregation/ui-kit/element/IMultiStaticSelectElement.ts
+++ b/news-aggregation/ui-kit/element/IMultiStaticSelectElement.ts
@@ -1,6 +1,6 @@
-import { MultiStaticSelectElement, TextObject } from '@rocket.chat/ui-kit';
+import { MultiStaticSelectElement } from '@rocket.chat/ui-kit';
 
 export type MultiStaticSelectParam = Omit<
 	MultiStaticSelectElement,
 	'type' | 'blockId' | 'actionId' | 'placeholder' | 'appId'
-> & { placeholder: TextObject };
+> & { text: string };

--- a/news-aggregation/ui-kit/element/IMultiStaticSelectElement.ts
+++ b/news-aggregation/ui-kit/element/IMultiStaticSelectElement.ts
@@ -1,0 +1,6 @@
+import { MultiStaticSelectElement, TextObject } from '@rocket.chat/ui-kit';
+
+export type MultiStaticSelectParam = Omit<
+	MultiStaticSelectElement,
+	'type' | 'blockId' | 'actionId' | 'placeholder' | 'appId'
+> & { placeholder: TextObject };

--- a/news-aggregation/ui-kit/element/IPlainTextInputElement.ts
+++ b/news-aggregation/ui-kit/element/IPlainTextInputElement.ts
@@ -1,0 +1,6 @@
+import { PlainTextInputElement } from '@rocket.chat/ui-kit';
+
+export type PlainTextInputParam = Omit<
+	PlainTextInputElement,
+	'type' | 'placeholder' | 'appId' | 'blockId' | 'actionId'
+> & { text: string };

--- a/news-aggregation/ui-kit/element/IStaticSelectElement.ts
+++ b/news-aggregation/ui-kit/element/IStaticSelectElement.ts
@@ -1,0 +1,17 @@
+import { StaticSelectElement, TextObject } from '@rocket.chat/ui-kit';
+
+export type StaticSelectParam = Pick<
+	StaticSelectElement,
+	| 'options'
+	| 'optionGroups'
+	| 'initialOption'
+	| 'initialValue'
+	| 'dispatchActionConfig'
+> & { placeholder: TextObject };
+
+export type StaticSelectOptionParam = Array<{
+	text: TextObject;
+	value: string;
+	description?: string;
+	url?: string;
+}>;

--- a/news-aggregation/ui-kit/element/IStaticSelectElement.ts
+++ b/news-aggregation/ui-kit/element/IStaticSelectElement.ts
@@ -1,4 +1,4 @@
-import { StaticSelectElement, TextObject } from '@rocket.chat/ui-kit';
+import { StaticSelectElement } from '@rocket.chat/ui-kit';
 
 export type StaticSelectParam = Pick<
 	StaticSelectElement,
@@ -10,7 +10,7 @@ export type StaticSelectParam = Pick<
 > & { placeholder: string };
 
 export type StaticSelectOptionParam = Array<{
-	text: TextObject;
+	text: string;
 	value: string;
 	description?: string;
 	url?: string;

--- a/news-aggregation/ui-kit/element/IStaticSelectElement.ts
+++ b/news-aggregation/ui-kit/element/IStaticSelectElement.ts
@@ -7,7 +7,7 @@ export type StaticSelectParam = Pick<
 	| 'initialOption'
 	| 'initialValue'
 	| 'dispatchActionConfig'
-> & { placeholder: TextObject };
+> & { placeholder: string };
 
 export type StaticSelectOptionParam = Array<{
 	text: TextObject;


### PR DESCRIPTION
This PR includes the setup of the `ElementBuilder` class which implements the `IElementBuilder` interface

The following types are defined in this PR:
- [x] IButtonElement
- [x] IElementBuilder
- [x] IInteractionElement
- [x] IStaticSelectElement
- [x] IMultiStaticSelectElement
- [x] IImageElement
- [x] IPlainTextInputElement

More can be added as and when required.

<br/>

The following methods are implemented to get various ui-kit block elements:
- [x] createButton
- [x] createDropdown
- [x] createDropdownOptions
- [x] createMultiStaticSelectDropdown
- [x] createImage
- [x] createPlainTextInput

More can be added as and when required.
