### PR TITLE
BlockBuilder setup

### DIFF
--- a/news-aggregation/builders/BlockBuilder.ts
+++ b/news-aggregation/builders/BlockBuilder.ts
@@ -1,0 +1,138 @@
+import {
+	ActionsBlock,
+	ContextBlock,
+	DividerBlock,
+	InputBlock,
+	LayoutBlockType,
+	PreviewBlockBase,
+	PreviewBlockWithThumb,
+	SectionBlock,
+	TextObject,
+	TextObjectType,
+} from '@rocket.chat/ui-kit';
+import { IBlockBuilder } from '../ui-kit/block/IBlockBuilder';
+import { SectionBlockParam } from '../ui-kit/block/ISectionBlock';
+import { ActionBlockParam } from '../ui-kit/block/IActionBlock';
+import { PreviewBlockParam } from '../ui-kit/block/IPreviewBlock';
+import { ContextBlockParam } from '../ui-kit/block/IContextBlock';
+import { InputBlockParam } from '../ui-kit/block/IInputBlock';
+
+export class BlockBuilder implements IBlockBuilder {
+	constructor(private readonly appId: string) {}
+
+	public createTextObjects(fields: Array<string>): Array<TextObject> {
+		const objects = fields?.map((field) => {
+			const textObject: TextObject = {
+				type: TextObjectType.PLAIN_TEXT,
+				text: field,
+				emoji: true,
+			};
+
+			return textObject;
+		});
+
+		return objects;
+	}
+
+	public createSectionBlock(param: SectionBlockParam): SectionBlock {
+		const { accessory, blockId, text, fields } = param;
+
+		const block: SectionBlock = {
+			type: LayoutBlockType.SECTION,
+			text: {
+				type: TextObjectType.PLAIN_TEXT,
+				text: text ? text : '',
+				emoji: true,
+			},
+			fields: fields ? this.createTextObjects(fields) : undefined,
+			accessory,
+			appId: this.appId,
+			blockId,
+		};
+
+		return block;
+	}
+
+	public createActionBlock(param: ActionBlockParam): ActionsBlock {
+		const { blockId, elements } = param;
+
+		const block: ActionsBlock = {
+			type: LayoutBlockType.ACTIONS,
+			elements,
+			appId: this.appId,
+			blockId,
+		};
+
+		return block;
+	}
+
+	public createPreviewBlock(
+		param: PreviewBlockParam
+	): PreviewBlockBase | PreviewBlockWithThumb {
+		const { title, description, footer, thumb } = param;
+
+		const block: PreviewBlockBase | PreviewBlockWithThumb = {
+			type: LayoutBlockType.PREVIEW,
+			title: this.createTextObjects(title),
+			description: this.createTextObjects(description),
+			footer,
+			thumb,
+		};
+
+		return block;
+	}
+
+	public createContextBlock(param: ContextBlockParam): ContextBlock {
+		const { contextElements, blockId } = param;
+
+		const elements = contextElements.map((element) => {
+			if (typeof element === 'string') {
+				return {
+					type: TextObjectType.MRKDWN,
+					text: element,
+				} as TextObject;
+			} else {
+				return element;
+			}
+		});
+
+		const block: ContextBlock = {
+			type: LayoutBlockType.CONTEXT,
+			elements,
+			appId: this.appId,
+			blockId,
+		};
+
+		return block;
+	}
+
+	public createInputBlock(param: InputBlockParam): InputBlock {
+		const { text, element, blockId, hint, optional } = param;
+
+		const block: InputBlock = {
+			type: LayoutBlockType.INPUT,
+			label: {
+				type: TextObjectType.PLAIN_TEXT,
+				text,
+				emoji: true,
+			},
+			element,
+			hint,
+			optional,
+			appId: this.appId,
+			blockId,
+		};
+
+		return block;
+	}
+
+	public createDividerBlock(blockId?: string | undefined): DividerBlock {
+		const block: DividerBlock = {
+			type: LayoutBlockType.DIVIDER,
+			appId: this.appId,
+			blockId,
+		};
+
+		return block;
+	}
+}

--- a/news-aggregation/ui-kit/block/IActionBlock.ts
+++ b/news-aggregation/ui-kit/block/IActionBlock.ts
@@ -1,0 +1,3 @@
+import { ActionsBlock } from '@rocket.chat/ui-kit';
+
+export type ActionBlockParam = Pick<ActionsBlock, 'blockId' | 'elements'>;

--- a/news-aggregation/ui-kit/block/IBlockBuilder.ts
+++ b/news-aggregation/ui-kit/block/IBlockBuilder.ts
@@ -1,6 +1,7 @@
 import {
 	ActionsBlock,
 	ContextBlock,
+	InputBlock,
 	PreviewBlockBase,
 	PreviewBlockWithThumb,
 	SectionBlock,
@@ -9,6 +10,7 @@ import { SectionBlockParam } from './ISectionBlock';
 import { ActionBlockParam } from './IActionBlock';
 import { PreviewBlockParam } from './IPreviewBlock';
 import { ContextBlockParam } from './IContextBlock';
+import { InputBlockParam } from './IInputBlock';
 
 export interface IBlockBuilder {
 	createSectionBlock(param: SectionBlockParam): SectionBlock;
@@ -21,7 +23,7 @@ export interface IBlockBuilder {
 
 	createContextBlock(param: ContextBlockParam): ContextBlock;
 
-	// createInputBlock(param: InputBlockParam): InputBlock;
+	createInputBlock(param: InputBlockParam): InputBlock;
 
 	// createDividerBlock(blockId?: string): DividerBlock;
 }

--- a/news-aggregation/ui-kit/block/IBlockBuilder.ts
+++ b/news-aggregation/ui-kit/block/IBlockBuilder.ts
@@ -1,0 +1,1 @@
+export interface IBlockBuilder {}

--- a/news-aggregation/ui-kit/block/IBlockBuilder.ts
+++ b/news-aggregation/ui-kit/block/IBlockBuilder.ts
@@ -1,1 +1,6 @@
-export interface IBlockBuilder {}
+import { SectionBlock } from '@rocket.chat/ui-kit';
+import { SectionBlockParam } from './ISectionBlock';
+
+export interface IBlockBuilder {
+	createSectionBlock(param: SectionBlockParam): SectionBlock;
+}

--- a/news-aggregation/ui-kit/block/IBlockBuilder.ts
+++ b/news-aggregation/ui-kit/block/IBlockBuilder.ts
@@ -1,15 +1,21 @@
-import { ActionsBlock, SectionBlock } from '@rocket.chat/ui-kit';
+import {
+	ActionsBlock,
+	PreviewBlockBase,
+	PreviewBlockWithThumb,
+	SectionBlock,
+} from '@rocket.chat/ui-kit';
 import { SectionBlockParam } from './ISectionBlock';
 import { ActionBlockParam } from './IActionBlock';
+import { PreviewBlockParam } from './IPreviewBlock';
 
 export interface IBlockBuilder {
 	createSectionBlock(param: SectionBlockParam): SectionBlock;
 
 	createActionBlock(param: ActionBlockParam): ActionsBlock;
 
-	// createPreviewBlock(
-	// 	param: PreviewBlockParam
-	// ): PreviewBlockBase | PreviewBlockWithThumb;
+	createPreviewBlock(
+		param: PreviewBlockParam
+	): PreviewBlockBase | PreviewBlockWithThumb;
 
 	// createContextBlock(param: ContextBlockParam): ContextBlock;
 

--- a/news-aggregation/ui-kit/block/IBlockBuilder.ts
+++ b/news-aggregation/ui-kit/block/IBlockBuilder.ts
@@ -1,6 +1,7 @@
 import {
 	ActionsBlock,
 	ContextBlock,
+	DividerBlock,
 	InputBlock,
 	PreviewBlockBase,
 	PreviewBlockWithThumb,
@@ -25,5 +26,5 @@ export interface IBlockBuilder {
 
 	createInputBlock(param: InputBlockParam): InputBlock;
 
-	// createDividerBlock(blockId?: string): DividerBlock;
+	createDividerBlock(blockId?: string): DividerBlock;
 }

--- a/news-aggregation/ui-kit/block/IBlockBuilder.ts
+++ b/news-aggregation/ui-kit/block/IBlockBuilder.ts
@@ -1,6 +1,19 @@
-import { SectionBlock } from '@rocket.chat/ui-kit';
+import { ActionsBlock, SectionBlock } from '@rocket.chat/ui-kit';
 import { SectionBlockParam } from './ISectionBlock';
+import { ActionBlockParam } from './IActionBlock';
 
 export interface IBlockBuilder {
 	createSectionBlock(param: SectionBlockParam): SectionBlock;
+
+	createActionBlock(param: ActionBlockParam): ActionsBlock;
+
+	// createPreviewBlock(
+	// 	param: PreviewBlockParam
+	// ): PreviewBlockBase | PreviewBlockWithThumb;
+
+	// createContextBlock(param: ContextBlockParam): ContextBlock;
+
+	// createInputBlock(param: InputBlockParam): InputBlock;
+
+	// createDividerBlock(blockId?: string): DividerBlock;
 }

--- a/news-aggregation/ui-kit/block/IBlockBuilder.ts
+++ b/news-aggregation/ui-kit/block/IBlockBuilder.ts
@@ -1,5 +1,6 @@
 import {
 	ActionsBlock,
+	ContextBlock,
 	PreviewBlockBase,
 	PreviewBlockWithThumb,
 	SectionBlock,
@@ -7,6 +8,7 @@ import {
 import { SectionBlockParam } from './ISectionBlock';
 import { ActionBlockParam } from './IActionBlock';
 import { PreviewBlockParam } from './IPreviewBlock';
+import { ContextBlockParam } from './IContextBlock';
 
 export interface IBlockBuilder {
 	createSectionBlock(param: SectionBlockParam): SectionBlock;
@@ -17,7 +19,7 @@ export interface IBlockBuilder {
 		param: PreviewBlockParam
 	): PreviewBlockBase | PreviewBlockWithThumb;
 
-	// createContextBlock(param: ContextBlockParam): ContextBlock;
+	createContextBlock(param: ContextBlockParam): ContextBlock;
 
 	// createInputBlock(param: InputBlockParam): InputBlock;
 

--- a/news-aggregation/ui-kit/block/IContextBlock.ts
+++ b/news-aggregation/ui-kit/block/IContextBlock.ts
@@ -1,0 +1,6 @@
+import { ImageElement } from '@rocket.chat/ui-kit';
+
+export type ContextBlockParam = {
+	contextElements: Array<string | ImageElement>;
+	blockId?: string;
+};

--- a/news-aggregation/ui-kit/block/IInputBlock.ts
+++ b/news-aggregation/ui-kit/block/IInputBlock.ts
@@ -1,0 +1,5 @@
+import { InputBlock } from '@rocket.chat/ui-kit';
+
+export type InputBlockParam = Omit<InputBlock, 'type' | 'appId' | 'label'> & {
+	text: string;
+};

--- a/news-aggregation/ui-kit/block/IPreviewBlock.ts
+++ b/news-aggregation/ui-kit/block/IPreviewBlock.ts
@@ -1,0 +1,8 @@
+import { PreviewBlockWithThumb } from '@rocket.chat/ui-kit';
+
+export type PreviewBlockParam = Partial<
+	Pick<PreviewBlockWithThumb, 'footer' | 'thumb'>
+> & {
+	title: Array<string>;
+	description: Array<string>;
+};

--- a/news-aggregation/ui-kit/block/ISectionBlock.ts
+++ b/news-aggregation/ui-kit/block/ISectionBlock.ts
@@ -1,0 +1,6 @@
+import { SectionBlock } from '@rocket.chat/ui-kit';
+
+export type SectionBlockParam = Pick<SectionBlock, 'accessory' | 'blockId'> & {
+	text?: string;
+	fields?: Array<string>;
+};


### PR DESCRIPTION
This PR includes the setup of the `BlockBuilder` class which implements the `IBlockBuilder` interface

The following types are defined in this PR:
- [x] ISectionBlock
- [x] IActionBlock
- [x] IPreviewBlock
- [x] IContextBlock
- [x] IInputBlock

More can be added as and when required.

<br />


The following methods are implemented to get various ui-kit block elements:
- [x] createSectionBlock
- [x] createActionBlock
- [x] createPreviewBlock
- [x] createContextBlock
- [x] createInputBlock
- [x] createDividerBlock

More can be added as and when required.
